### PR TITLE
feat: Windows

### DIFF
--- a/generate_schedule_milp/src/cli.rs
+++ b/generate_schedule_milp/src/cli.rs
@@ -1,4 +1,5 @@
 use std::env;
+use crate::domain::WindowSpec;
 
 #[derive(Debug, Clone, Copy)]
 pub enum ScheduleStrategy {
@@ -8,24 +9,25 @@ pub enum ScheduleStrategy {
 
 #[derive(Debug, Clone)]
 pub struct ScheduleConfig {
-    pub day_start_minutes: i32,  // e.g. 8*60 for 8:00 AM
-    pub day_end_minutes: i32,    // e.g. 22*60 for 10:00 PM
+    pub day_start_minutes: i32,  // e.g. 8*60
+    pub day_end_minutes: i32,    // e.g. 22*60
     pub strategy: ScheduleStrategy,
+
+    // New field for global windows
+    pub global_windows: Vec<WindowSpec>,
 }
 
 impl Default for ScheduleConfig {
     fn default() -> Self {
         Self {
-            day_start_minutes: 8 * 60,  // 8:00 AM default
-            day_end_minutes: 22 * 60,   // 10:00 PM default
+            day_start_minutes: 8 * 60,
+            day_end_minutes: 22 * 60,
             strategy: ScheduleStrategy::Earliest,
+            global_windows: Vec::new(),
         }
     }
 }
 
-/// Parses command-line arguments to set:
-/// - day window start/end via --start=HH:MM and --end=HH:MM
-/// - scheduling strategy (earliest vs. latest), e.g. "cargo run latest"
 pub fn parse_config_from_args() -> ScheduleConfig {
     let args: Vec<String> = env::args().collect();
     let mut config = ScheduleConfig::default();
@@ -35,21 +37,69 @@ pub fn parse_config_from_args() -> ScheduleConfig {
         args.iter()
             .find_map(|arg| arg.strip_prefix(prefix))
             .and_then(|time_str| time_str.split_once(':'))
-            .and_then(|(h_str, m_str)| 
+            .and_then(|(h_str, m_str)| {
                 h_str.parse::<i32>().ok().zip(m_str.parse::<i32>().ok())
                     .map(|(h, m)| *minutes = h * 60 + m)
-            );
+            });
     };
-
     parse_time_arg("--start=", &mut config.day_start_minutes);
     parse_time_arg("--end=", &mut config.day_end_minutes);
 
-    // 2) Strategy: if user typed "latest" anywhere, we switch from Earliest to Latest
-    // e.g. "cargo run latest" or "cargo run -- latest"
+    // 2) Strategy
     if args.iter().any(|a| a.eq_ignore_ascii_case("latest")) {
         config.strategy = ScheduleStrategy::Latest;
     }
 
-    // Otherwise it remains Earliest (the default)
+    // 3) Global windows: e.g. --windows=08:00,12:00-13:00,18:00
+    // We parse them similarly to parse_one_window in parse.rs but inlined for brevity.
+    if let Some(win_arg) = args.iter().find(|a| a.starts_with("--windows=")) {
+        let raw = &win_arg["--windows=".len()..];
+        config.global_windows = parse_windows_string(raw)
+            .unwrap_or_else(|e| {
+                eprintln!("Warning: could not parse windows from '{}': {}", raw, e);
+                Vec::new()
+            });
+    }
+
     config
+}
+
+// Minimal parse logic for CLI windows.
+// This can mirror your parse_one_window from parse.rs, or call a shared function.
+fn parse_windows_string(input: &str) -> Result<Vec<WindowSpec>, String> {
+    // Example: "08:00,12:00-13:00,19:00"
+    let parts: Vec<_> = input.split(',').map(|p| p.trim()).collect();
+    let mut specs = Vec::new();
+    for part in parts {
+        if part.is_empty() {
+            continue;
+        }
+        if let Some(idx) = part.find('-') {
+            // Range
+            let (start_str, end_str) = part.split_at(idx);
+            let end_str = &end_str[1..];
+            let start_min = hhmm_to_minutes(start_str.trim())?;
+            let end_min = hhmm_to_minutes(end_str.trim())?;
+            if end_min < start_min {
+                return Err(format!("Invalid window range: {}", part));
+            }
+            specs.push(WindowSpec::Range(start_min, end_min));
+        } else {
+            // Anchor
+            let anchor = hhmm_to_minutes(part)?;
+            specs.push(WindowSpec::Anchor(anchor));
+        }
+    }
+    Ok(specs)
+}
+
+// Simplified version of parse_hhmm_to_minutes
+fn hhmm_to_minutes(hhmm: &str) -> Result<i32, String> {
+    let mut split = hhmm.split(':');
+    let h = split.next().ok_or("Missing hour")?.parse::<i32>().map_err(|_| "Bad hour")?;
+    let m = split.next().ok_or("Missing minute")?.parse::<i32>().map_err(|_| "Bad minute")?;
+    if !(0..=23).contains(&h) || !(0..=59).contains(&m) {
+        return Err(format!("Out of range: {}", hhmm));
+    }
+    Ok(h * 60 + m)
 }

--- a/generate_schedule_milp/src/domain.rs
+++ b/generate_schedule_milp/src/domain.rs
@@ -1,10 +1,18 @@
 use good_lp::variable::Variable;
 
 #[derive(Debug, Clone)]
-pub enum ConstraintType { Before, After, Apart, ApartFrom }
+pub enum ConstraintType {
+    Before,
+    After,
+    Apart,
+    ApartFrom,
+}
 
 #[derive(Debug, Clone)]
-pub enum ConstraintRef { WithinGroup, Unresolved(String) }
+pub enum ConstraintRef {
+    WithinGroup,
+    Unresolved(String),
+}
 
 #[derive(Debug, Clone)]
 pub struct ConstraintExpr {
@@ -31,7 +39,7 @@ impl Frequency {
             _ => Self::EveryXHours(8),
         }
     }
-    
+
     pub fn instances_per_day(&self) -> usize {
         match self {
             Self::Daily => 1,
@@ -42,12 +50,29 @@ impl Frequency {
     }
 }
 
+/// Represents a desired scheduling “window,” which can be:
+///   - A single anchor time (in minutes from midnight), e.g. 480 for 08:00
+///   - A start–end range in minutes (e.g. 720..780 for 12:00–13:00)
+#[derive(Debug, Clone)]
+pub enum WindowSpec {
+    Anchor(i32),
+    Range(i32, i32),
+}
+
+/// An “entity” to be scheduled.
+/// - `constraints` are the typical “Apart”, “Before”, etc. constraints
+/// - `windows` is optional extra data: if nonempty, the solver may need
+///   to place this entity in one of these windows, or near these anchors.
 #[derive(Debug, Clone)]
 pub struct Entity {
     pub name: String,
     pub category: String,
     pub frequency: Frequency,
     pub constraints: Vec<ConstraintExpr>,
+
+    /// New field: a list of windows (anchors or ranges) associated with this entity.
+    /// If empty, the entity has no special windows and may be placed by global logic.
+    pub windows: Vec<WindowSpec>,
 }
 
 #[derive(Clone)]

--- a/generate_schedule_milp/src/main.rs
+++ b/generate_schedule_milp/src/main.rs
@@ -592,9 +592,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             let e = entities.iter().find(|e| e.name == *ename).unwrap();
 
             for w_idx in 0..e.windows.len() {
-                let window_desc = match &entity_windows.get(ename).unwrap()[w_idx].time_desc {
-                    desc => desc.clone(),
-                };
+                let desc = &entity_windows.get(ename).unwrap()[w_idx].time_desc;
+                let window_desc = desc.clone();
 
                 let mut users = Vec::new();
                 for (instance, idx) in instance_window_map.keys() {

--- a/generate_schedule_milp/src/main.rs
+++ b/generate_schedule_milp/src/main.rs
@@ -22,13 +22,11 @@ struct PenaltyVar {
     entity_name: String,
     instance: usize,
     var: Variable,
-    windows: Vec<WindowSpec>,
 }
 
 // Structure to capture window information for better reporting
 #[derive(Debug, Clone)]
 struct WindowInfo {
-    window_type: String,
     time_desc: String,
 }
 
@@ -365,7 +363,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 entity_name: e.name.clone(),
                 instance: cv.instance,
                 var: p_i,
-                windows: e.windows.clone(),
             });
 
             // Create one distance variable for each window
@@ -693,7 +690,6 @@ fn create_window_info_map(entities: &[Entity]) -> HashMap<String, Vec<WindowInfo
                     let hh = a / 60;
                     let mm = a % 60;
                     windows.push(WindowInfo {
-                        window_type: "Anchor".to_string(),
                         time_desc: format!("{:02}:{:02}", hh, mm),
                     });
                 },
@@ -703,7 +699,6 @@ fn create_window_info_map(entities: &[Entity]) -> HashMap<String, Vec<WindowInfo
                     let end_hh = end / 60;
                     let end_mm = end % 60;
                     windows.push(WindowInfo {
-                        window_type: "Range".to_string(),
                         time_desc: format!("{:02}:{:02}-{:02}:{:02}", 
                                           start_hh, start_mm, end_hh, end_mm),
                     });

--- a/generate_schedule_milp/src/main.rs
+++ b/generate_schedule_milp/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             "null",
             "2x daily",
             "[]",               // no 'apart' constraints
-            "[\"08:00\", \"12:00-13:00\", \"19:00\"]", // has 2 anchors & 1 range
+            "[\"08:00\", \"18:00-20:00\"]", // has 1 anchor & 1 range
             "some note",
         ],
     ];

--- a/generate_schedule_milp/src/main.rs
+++ b/generate_schedule_milp/src/main.rs
@@ -247,7 +247,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 for c_r in &rvars {
                     let b = builder.add(variable().binary());
                     let d1 = format!("(ApartFrom) {} - {} >= {} - bigM*(1-b)",
-                        c2str(c_r), c2str(&c_e), tv);
+                        c2str(c_r), c2str(c_e), tv);
                     add_constraint(&d1,
                         constraint!(c_r.var - c_e.var >= tv - big_m*(1.0 - b)),
                         &mut constraints,
@@ -255,7 +255,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     );
 
                     let d2 = format!("(ApartFrom) {} - {} >= {} - bigM*b",
-                        c2str(&c_e), c2str(c_r), tv);
+                        c2str(c_e), c2str(c_r), tv);
                     add_constraint(&d2,
                         constraint!(c_e.var - c_r.var >= tv - big_m*b),
                         &mut constraints,
@@ -275,7 +275,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         for c_r in &rvars {
                             let b = builder.add(variable().binary());
                             let d1 = format!("(Before|After) {} - {} >= {} - M*(1-b)",
-                                c2str(c_r), c2str(&c_e), bv);
+                                c2str(c_r), c2str(c_e), bv);
                             add_constraint(&d1,
                                 constraint!(c_r.var - c_e.var >= bv - big_m*(1.0 - b)),
                                 &mut constraints,
@@ -283,7 +283,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             );
 
                             let d2 = format!("(Before|After) {} - {} >= {} - M*b",
-                                c2str(&c_e), c2str(c_r), av);
+                                c2str(c_e), c2str(c_r), av);
                             add_constraint(&d2,
                                 constraint!(c_e.var - c_r.var >= av - big_m*b),
                                 &mut constraints,

--- a/generate_schedule_milp/src/main.rs
+++ b/generate_schedule_milp/src/main.rs
@@ -3,24 +3,43 @@ mod parse;
 mod cli;
 
 use crate::cli::{ScheduleStrategy, parse_config_from_args};
-use crate::domain::{ClockVar, ConstraintType, ConstraintRef, c2str, WindowSpec};
+use crate::domain::{
+    ClockVar, ConstraintType, ConstraintRef, c2str,
+    WindowSpec, Entity, // needed to match on WindowSpec
+};
 use crate::parse::parse_from_table;
 
 use good_lp::{
     variables, variable, constraint, default_solver,
-    SolverModel, Solution, Expression, Constraint
+    SolverModel, Solution, Expression, Constraint, Variable
 };
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::time::Instant;
+
+// Custom structure to track penalty variables for better reporting
+struct PenaltyVar {
+    entity_name: String,
+    instance: usize,
+    var: Variable,
+    windows: Vec<WindowSpec>,
+}
+
+// Structure to capture window information for better reporting
+#[derive(Debug, Clone)]
+struct WindowInfo {
+    window_type: String,
+    time_desc: String,
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let start_time = Instant::now();
+    
     let config = parse_config_from_args();
     println!("Using day window: {}..{} (in minutes)", config.day_start_minutes, config.day_end_minutes);
     println!("Strategy: {:?}", config.strategy);
 
-    // "Best of both worlds" alpha:
-    let alpha = 0.2;
-
+    // Sample table data
     let table_data = vec![
         vec![
             "Entity",
@@ -84,13 +103,17 @@ fn main() -> Result<(), Box<dyn Error>> {
             "null",
             "null",
             "2x daily",
-            "[]",
+            "[]",               // no 'apart' constraints
             "[\"08:00\", \"12:00-13:00\", \"19:00\"]", // has 2 anchors & 1 range
-            "null",
+            "some note",
         ],
     ];
 
+    // Parse table data
     let entities = parse_from_table(table_data)?;
+
+    // Create a map of window info for better reporting
+    let entity_windows = create_window_info_map(&entities);
 
     // Build category->entities map
     let mut category_map = HashMap::new();
@@ -100,36 +123,43 @@ fn main() -> Result<(), Box<dyn Error>> {
             .insert(e.name.clone());
     }
 
+    // Create variables for each entity instance, within [start..end]
     let mut builder = variables!();
-
-    // Build clock variables
     let mut clock_map = HashMap::new();
     for e in &entities {
         let count = e.frequency.instances_per_day();
         for i in 0..count {
             let cname = format!("{}_{}", e.name, i+1);
-            // default is float/continuous if we don't call .integer() or .binary()
-            let var = builder.add(
-                variable()
+            let var = builder
+                .add(variable()
+                    .integer()
                     .min(config.day_start_minutes as f64)
                     .max(config.day_end_minutes as f64)
+                );
+            clock_map.insert(
+                cname,
+                ClockVar {
+                    entity_name: e.name.clone(),
+                    instance: i+1,
+                    var,
+                },
             );
-            clock_map.insert(cname, ClockVar {
-                entity_name: e.name.clone(),
-                instance: i+1,
-                var,
-            });
         }
     }
 
-    // We'll store constraints in a vector
+    // We collect constraints here
     let mut constraints = Vec::new();
-    fn add_dbg(desc: &str, c: Constraint, vec: &mut Vec<Constraint>) {
-        println!("DEBUG => {desc}");
+    
+    // More concise debug function with toggle
+    let debug_enabled = true;
+    fn add_constraint(desc: &str, c: Constraint, vec: &mut Vec<Constraint>, debug: bool) {
+        if debug {
+            println!("DEBUG => {desc}");
+        }
         vec.push(c);
     }
 
-    // entity -> Vec of clock vars
+    // Make a map: entity -> [its clockvars]
     let mut entity_clocks: HashMap<String, Vec<ClockVar>> = HashMap::new();
     for cv in clock_map.values() {
         entity_clocks.entry(cv.entity_name.clone())
@@ -140,7 +170,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         list.sort_by_key(|c| c.instance);
     }
 
-    // Helper to resolve references by name or category
+    // Helper to resolve references: either an entity name or a category
     let resolve_ref = |rstr: &str| -> Vec<ClockVar> {
         let mut out = Vec::new();
         for e in &entities {
@@ -165,10 +195,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let big_m = 1440.0;
 
-    // 1) apart/before/after constraints
+    // (1) Apply "apart/before/after" constraints
     for e in &entities {
         let eclocks = match entity_clocks.get(&e.name) {
-            Some(cl) => cl,
+            Some(list) => list,
             None => continue,
         };
 
@@ -177,7 +207,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let mut apart_from_list = Vec::new();
 
         for cexpr in &e.constraints {
-            let tv_min = cexpr.time_hours as f64 * 60.0;
+            let tv_min = (cexpr.time_hours as f64) * 60.0;
             match cexpr.ctype {
                 ConstraintType::Apart => {
                     apart_intervals.push(tv_min);
@@ -202,58 +232,91 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
 
-        // a) consecutive "apart"
+        // (a) "apart" for consecutive instances
         for tv in apart_intervals {
             for w in eclocks.windows(2) {
                 let c1 = &w[0];
                 let c2 = &w[1];
                 let desc = format!("(Apart) {} - {} >= {}", c2str(c2), c2str(c1), tv);
-                add_dbg(&desc, constraint!( c2.var - c1.var >= tv ), &mut constraints);
+                add_constraint(&desc, constraint!(c2.var - c1.var >= tv), &mut constraints, debug_enabled);
             }
         }
 
-        // b) "apart_from"
+        // (b) "apart_from" => big-M disjunction
         for (tv, refname) in apart_from_list {
             let rvars = resolve_ref(&refname);
             for c_e in eclocks {
                 for c_r in &rvars {
                     let b = builder.add(variable().binary());
-                    let d1 = format!("(ApartFrom) {} - {} >= {} - bigM*(1-b)", c2str(c_r), c2str(c_e), tv);
-                    add_dbg(&d1, constraint!( c_r.var - c_e.var >= tv - big_m*(1.0 - b)), &mut constraints);
-                    let d2 = format!("(ApartFrom) {} - {} >= {} - bigM*b", c2str(c_e), c2str(c_r), tv);
-                    add_dbg(&d2, constraint!( c_e.var - c_r.var >= tv - big_m*b ), &mut constraints);
+                    let d1 = format!("(ApartFrom) {} - {} >= {} - bigM*(1-b)",
+                        c2str(c_r), c2str(&c_e), tv);
+                    add_constraint(&d1, 
+                        constraint!(c_r.var - c_e.var >= tv - big_m*(1.0 - b)), 
+                        &mut constraints, 
+                        debug_enabled
+                    );
+                    
+                    let d2 = format!("(ApartFrom) {} - {} >= {} - bigM*b",
+                        c2str(&c_e), c2str(c_r), tv);
+                    add_constraint(&d2,
+                        constraint!(c_e.var - c_r.var >= tv - big_m*b),
+                        &mut constraints,
+                        debug_enabled
+                    );
                 }
             }
         }
 
-        // c) merges of "before & after"
+        // (c) merges of "before & after"
         for (rname, (maybe_b, maybe_a)) in ba_map {
             let rvars = resolve_ref(&rname);
             match (maybe_b, maybe_a) {
                 (Some(bv), Some(av)) => {
+                    // "≥bv before" OR "≥av after" disjunction
                     for c_e in eclocks {
                         for c_r in &rvars {
                             let b = builder.add(variable().binary());
-                            let d1 = format!("(Before|After) {} - {} >= {} - M*(1-b)", c2str(c_r), c2str(c_e), bv);
-                            add_dbg(&d1, constraint!( c_r.var - c_e.var >= bv - big_m*(1.0 - b) ), &mut constraints);
-                            let d2 = format!("(Before|After) {} - {} >= {} - M*b", c2str(c_e), c2str(c_r), av);
-                            add_dbg(&d2, constraint!( c_e.var - c_r.var >= av - big_m*b ), &mut constraints);
+                            let d1 = format!("(Before|After) {} - {} >= {} - M*(1-b)",
+                                c2str(c_r), c2str(&c_e), bv);
+                            add_constraint(&d1,
+                                constraint!(c_r.var - c_e.var >= bv - big_m*(1.0 - b)),
+                                &mut constraints,
+                                debug_enabled
+                            );
+                            
+                            let d2 = format!("(Before|After) {} - {} >= {} - M*b",
+                                c2str(&c_e), c2str(c_r), av);
+                            add_constraint(&d2,
+                                constraint!(c_e.var - c_r.var >= av - big_m*b),
+                                &mut constraints,
+                                debug_enabled
+                            );
                         }
                     }
                 }
                 (Some(bv), None) => {
+                    // only "before"
                     for c_e in eclocks {
                         for c_r in &rvars {
                             let d = format!("(Before) {} - {} >= {}", c2str(c_r), c2str(c_e), bv);
-                            add_dbg(&d, constraint!( c_r.var - c_e.var >= bv ), &mut constraints);
+                            add_constraint(&d, 
+                                constraint!(c_r.var - c_e.var >= bv), 
+                                &mut constraints,
+                                debug_enabled
+                            );
                         }
                     }
                 }
                 (None, Some(av)) => {
+                    // only "after"
                     for c_e in eclocks {
                         for c_r in &rvars {
                             let d = format!("(After) {} - {} >= {}", c2str(c_e), c2str(c_r), av);
-                            add_dbg(&d, constraint!( c_e.var - c_r.var >= av ), &mut constraints);
+                            add_constraint(&d, 
+                                constraint!(c_e.var - c_r.var >= av), 
+                                &mut constraints,
+                                debug_enabled
+                            );
                         }
                     }
                 }
@@ -262,87 +325,230 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("DEBUG => Using alpha = {alpha} for soft-window penalties.");
+    // (2) SOFT penalty for window preferences
+    // Use a moderate alpha that balances earliest/latest with window preferences
+    let alpha = 0.3;
 
-    // We'll track penalty variables
-    let mut penalty_vars = Vec::new();
+    println!("\n--- Creating soft window penalty constraints (α = {}) ---", alpha);
 
-    // 2) Soft windows: measure "distance from at least one window"
+    // Track penalty variables for better reporting
+    let mut penalty_vars: Vec<PenaltyVar> = Vec::new();
+    
+    // Track which windows are used by which instances
+    let mut window_usage_vars: HashMap<String, HashMap<(usize, usize), Variable>> = HashMap::new();
+
     for e in &entities {
+        // Skip entities with no windows - they won't have penalties
         if e.windows.is_empty() {
             continue;
         }
-        println!("DEBUG => Entity '{}' has {} windows => will penalize distance", e.name, e.windows.len());
+        
+        println!("Entity '{}': {} windows defined", e.name, e.windows.len());
+        
+        // Get clock variables for this entity
+        let eclocks = match entity_clocks.get(&e.name) {
+            Some(list) => list,
+            None => continue,
+        };
+        
+        // If we have multiple instances and multiple windows, track window usage
+        let track_window_usage = eclocks.len() > 1 && e.windows.len() > 1;
+        let mut instance_window_vars = HashMap::new();
 
-        if let Some(clocks) = entity_clocks.get(&e.name) {
-            for cv in clocks {
-                // This is the penalty var for this clock
-                let p_i = builder.add(variable().min(0.0)); 
-                penalty_vars.push(p_i);
+        // Process each clock variable (instance) for this entity
+        for cv in eclocks {
+            // Create a penalty variable p_i for this instance
+            let p_i = builder.add(variable().min(0.0));
+            
+            // Store penalty info for reporting
+            penalty_vars.push(PenaltyVar {
+                entity_name: e.name.clone(),
+                instance: cv.instance,
+                var: p_i,
+                windows: e.windows.clone(),
+            });
 
-                // For each window, define a dist_iw var
-                // then p_i <= dist_iw
-                for (w_idx, wspec) in e.windows.iter().enumerate() {
-                    let dist_iw = builder.add(variable().min(0.0));
+            // Create one distance variable for each window
+            for (w_idx, wspec) in e.windows.iter().enumerate() {
+                let dist_iw = builder.add(variable().min(0.0));
 
-                    match wspec {
-                        WindowSpec::Anchor(a) => {
-                            // dist_iw >= var - a
-                            let d1 = format!("(SoftAnchor+) dist_{}_{} >= {} - {}", c2str(cv), w_idx, c2str(cv), a);
-                            add_dbg(&d1, constraint!( dist_iw >= cv.var - (*a as f64) ), &mut constraints);
+                // For window distribution tracking
+                if track_window_usage {
+                    // Create binary variable indicating if this instance uses this window
+                    let window_use_var = builder.add(variable().binary());
+                    instance_window_vars.insert((cv.instance, w_idx), window_use_var);
+                    
+                    // Define "using a window" as being within 30 minutes of it
+                    let use_threshold = 30.0;
+                    
+                    // If dist_iw <= use_threshold then window_use_var = 1
+                    // Using big-M: dist_iw <= use_threshold + M*(1-window_use_var)
+                    add_constraint(
+                        &format!("(WinUse) {}_{} uses win{} if dist <= {}", 
+                                 e.name, cv.instance, w_idx, use_threshold),
+                        constraint!(dist_iw <= use_threshold + big_m*(1.0 - window_use_var)),
+                        &mut constraints,
+                        debug_enabled
+                    );
+                    
+                    // If dist_iw > use_threshold then window_use_var = 0
+                    // Using big-M: dist_iw >= use_threshold - M*window_use_var
+                    add_constraint(
+                        &format!("(WinUse) {}_{} doesn't use win{} if dist > {}", 
+                                 e.name, cv.instance, w_idx, use_threshold),
+                        constraint!(dist_iw >= use_threshold - big_m*window_use_var),
+                        &mut constraints,
+                        debug_enabled
+                    );
+                }
 
-                            // dist_iw >= a - var
-                            let d2 = format!("(SoftAnchor-) dist_{}_{} >= {} - {}", c2str(cv), w_idx, a, c2str(cv));
-                            add_dbg(&d2, constraint!( dist_iw >= (*a as f64) - cv.var ), &mut constraints);
-                        }
-                        WindowSpec::Range(start, end) => {
-                            // dist_iw >= start - var
-                            let d1 = format!("(SoftRangeStart) dist_{}_{} >= {} - {}", c2str(cv), w_idx, start, c2str(cv));
-                            add_dbg(&d1, constraint!( dist_iw >= (*start as f64) - cv.var ), &mut constraints);
-
-                            // dist_iw >= var - end
-                            let d2 = format!("(SoftRangeEnd) dist_{}_{} >= {} - {}", c2str(cv), w_idx, c2str(cv), end);
-                            add_dbg(&d2, constraint!( dist_iw >= cv.var - (*end as f64) ), &mut constraints);
-                        }
+                match wspec {
+                    WindowSpec::Anchor(a) => {
+                        // For anchors: |t_i - a| represented with two constraints
+                        // dist_iw >= t_i - a
+                        add_constraint(
+                            &format!("(Win+) dist_{}_w{} >= {} - {}", cv.instance, w_idx, c2str(cv), a),
+                            constraint!(dist_iw >= cv.var - (*a as f64)),
+                            &mut constraints,
+                            debug_enabled
+                        );
+                        
+                        // dist_iw >= a - t_i
+                        add_constraint(
+                            &format!("(Win-) dist_{}_w{} >= {} - {}", cv.instance, w_idx, a, c2str(cv)),
+                            constraint!(dist_iw >= (*a as f64) - cv.var),
+                            &mut constraints,
+                            debug_enabled
+                        );
+                    },
+                    WindowSpec::Range(start, end) => {
+                        // For ranges: 0 if inside, distance to closest edge if outside
+                        // dist_iw >= start - t_i (if t_i < start)
+                        add_constraint(
+                            &format!("(WinS) dist_{}_w{} >= {} - {}", cv.instance, w_idx, start, c2str(cv)),
+                            constraint!(dist_iw >= (*start as f64) - cv.var),
+                            &mut constraints,
+                            debug_enabled
+                        );
+                        
+                        // dist_iw >= t_i - end (if t_i > end)
+                        add_constraint(
+                            &format!("(WinE) dist_{}_w{} >= {} - {}", cv.instance, w_idx, c2str(cv), end),
+                            constraint!(dist_iw >= cv.var - (*end as f64)),
+                            &mut constraints,
+                            debug_enabled
+                        );
                     }
+                }
 
-                    // p_i <= dist_iw
-                    let dp = format!("(SoftWinPick) {}_p <= dist_{}_{}", c2str(cv), c2str(cv), w_idx);
-                    add_dbg(&dp, constraint!( p_i <= dist_iw ), &mut constraints);
+                // p_i <= dist_iw => p_i will be minimum distance to any window
+                add_constraint(
+                    &format!("(Win) p_{} <= dist_{}_w{}", cv.instance, cv.instance, w_idx),
+                    constraint!(p_i <= dist_iw),
+                    &mut constraints,
+                    debug_enabled
+                );
+            }
+        }
+        
+        // If we're tracking window usage for this entity, save the variables
+        if track_window_usage {
+            window_usage_vars.insert(e.name.clone(), instance_window_vars);
+        }
+    }
+    
+    // (3) Window distribution constraints
+    // Ensure instances of the same entity use different windows when possible
+    println!("\n--- Adding window distribution constraints ---");
+    
+    for (ename, instance_window_map) in &window_usage_vars {
+        let eclocks = entity_clocks.get(ename).unwrap();
+        let window_count = entities.iter()
+            .find(|e| &e.name == ename)
+            .map(|e| e.windows.len())
+            .unwrap_or(0);
+            
+        println!("Entity '{}': ensuring distribution across {} windows", ename, window_count);
+        
+        // Each instance must use exactly one window
+        for cv in eclocks {
+            let mut sum_expr = Expression::from(0.0);
+            for w_idx in 0..window_count {
+                if let Some(&use_var) = instance_window_map.get(&(cv.instance, w_idx)) {
+                    sum_expr += use_var;
                 }
             }
+            
+            add_constraint(
+                &format!("(Dist) {}_instance{} must use exactly one window", ename, cv.instance),
+                constraint!(sum_expr == 1.0),
+                &mut constraints,
+                debug_enabled
+            );
+        }
+        
+        // Each window can be used at most once
+        // (this forces distribution across windows)
+        for w_idx in 0..window_count {
+            let mut sum_expr = Expression::from(0.0);
+            for cv in eclocks {
+                if let Some(&use_var) = instance_window_map.get(&(cv.instance, w_idx)) {
+                    sum_expr += use_var;
+                }
+            }
+            
+            add_constraint(
+                &format!("(Dist) {}_window{} can be used at most once", ename, w_idx),
+                constraint!(sum_expr <= 1.0),
+                &mut constraints,
+                debug_enabled
+            );
         }
     }
 
-    // 3) Build objective
+    // (4) Build objective:
+    // For earliest => minimize(sum(t_i) + alpha * sum(p_i))
+    // For latest   => maximize(sum(t_i) - alpha * sum(p_i))
+    //               = minimize(-sum(t_i) + alpha * sum(p_i))
+    
+    // Sum of all time variables
     let mut sum_expr = Expression::from(0.0);
     for cv in clock_map.values() {
         sum_expr += cv.var;
     }
 
+    // Sum of all penalty variables
     let mut penalty_expr = Expression::from(0.0);
-    for &p in &penalty_vars {
-        penalty_expr += p;
+    for p in &penalty_vars {
+        penalty_expr += p.var;
     }
 
+    // Add all constraints to the problem
+    println!("\nSolving problem with {} constraints...", constraints.len());
+    
     let mut problem = match config.strategy {
         ScheduleStrategy::Earliest => {
-            println!("DEBUG => Objective: minimise sum(t_i) + {alpha} * sum(penalties)");
-            builder.minimise(sum_expr + alpha * penalty_expr).using(default_solver)
+            println!("\nObjective: minimize(sum(t_i) + {} * sum(p_i))", alpha);
+            builder.minimise(sum_expr + alpha * penalty_expr)
+                   .using(default_solver)
         }
         ScheduleStrategy::Latest => {
-            println!("DEBUG => Objective: minimise -sum(t_i) + {alpha} * sum(penalties) [i.e. max sum(t_i) - alpha*penalty]");
+            println!("\nObjective: maximize(sum(t_i) - {} * sum(p_i))", alpha);
+            // Equivalent to minimize(-sum_expr + alpha * penalty_expr)
             builder.minimise(Expression::from(0.0) - sum_expr + alpha * penalty_expr)
                    .using(default_solver)
         }
     };
 
-    // Add constraints
+    // 1) Take the length before consuming constraints.
+    let constraint_count = constraints.len();
+    
+    // 2) Now actually consume the constraints.
     for c in constraints {
         problem = problem.with(c);
     }
-
-    // Solve
+    let solve_start = Instant::now();
+    
     let sol = match problem.solve() {
         Ok(s) => s,
         Err(e) => {
@@ -350,35 +556,163 @@ fn main() -> Result<(), Box<dyn Error>> {
             return Err(format!("Solve error: {e}").into());
         }
     };
+    
+    let solve_time = solve_start.elapsed();
+    println!("Problem solved in {:.2?}", solve_time);
 
-    // Extract schedule
+    // Extract solution and organize for display
     let mut schedule = Vec::new();
     for (cid, cv) in &clock_map {
         let val = sol.value(cv.var);
-        schedule.push((cid.clone(), cv.entity_name.clone(), val));
+        schedule.push((cid.clone(), cv.entity_name.clone(), cv.instance, val));
     }
-    schedule.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+    schedule.sort_by(|a, b| a.3.partial_cmp(&b.3).unwrap());
 
-    println!("--- Final schedule ({:?}) ---", config.strategy);
-    for (cid, ename, t) in &schedule {
+    // Display the final schedule with formatting
+    println!("\n┌─────────────────────────────────────────────┐");
+    println!("│           FINAL SCHEDULE ({:?})          │", config.strategy);
+    println!("├─────────────────────────────────────────────┤");
+    println!("│ Time     | Instance                | Entity │");
+    println!("├──────────┼─────────────────────────┼────────┤");
+    
+    for (cid, ename, _instance, t) in &schedule {
         let hh = (t / 60.0).floor() as i32;
         let mm = (t % 60.0).round() as i32;
-        println!("  {cid} ({ename}): {hh:02}:{mm:02}");
+        println!("│ {:02}:{:02}    | {:<23} | {:<6} │", 
+                 hh, mm, cid, ename);
+    }
+    println!("└─────────────────────────────────────────────┘");
+
+    // Display window usage information
+    if !window_usage_vars.is_empty() {
+        println!("\n┌─────────────────────────────────────────────┐");
+        println!("│           WINDOW USAGE REPORT              │");
+        println!("├─────────────────────────────────────────────┤");
+        println!("│ Entity     | Window          | Used By      │");
+        println!("├────────────┼─────────────────┼──────────────┤");
+        
+        for (ename, instance_window_map) in &window_usage_vars {
+            let e = entities.iter().find(|e| e.name == *ename).unwrap();
+            
+            for w_idx in 0..e.windows.len() {
+                let window_desc = match &entity_windows.get(ename).unwrap()[w_idx].time_desc {
+                    desc => desc.clone(),
+                };
+                
+                let mut users = Vec::new();
+                for (instance, idx) in instance_window_map.keys() {
+                    if *idx == w_idx && sol.value(instance_window_map[&(*instance, *idx)]) > 0.5 {
+                        users.push(format!("#{}", instance));
+                    }
+                }
+                
+                let usage = if users.is_empty() { "None".to_string() } else { users.join(", ") };
+                
+                println!("│ {:<10} | {:<15} | {:<12} │", 
+                         ename, window_desc, usage);
+            }
+            println!("├────────────┼─────────────────┼──────────────┤");
+        }
+        println!("└─────────────────────────────────────────────┘");
     }
 
-    // Print penalty details
+    // Calculate and display window penalties
     if !penalty_vars.is_empty() {
-        println!("\n--- Window deviation penalties ---");
+        println!("\n┌───────────────────────────────────────────────────────┐");
+        println!("│                WINDOW ADHERENCE REPORT                │");
+        println!("├───────────────────────────────────────────────────────┤");
+        println!("│ Entity     | Instance | Deviation | Preferred Windows │");
+        println!("├────────────┼──────────┼───────────┼───────────────────┤");
+        
         let mut total_penalty = 0.0;
-        for (i, &p) in penalty_vars.iter().enumerate() {
-            let pval = sol.value(p);
-            if pval.abs() > 1e-6 {
-                println!("  penalty[{i}] = {pval}");
-            }
-            total_penalty += pval;
+        
+        for p in &penalty_vars {
+            let p_val = sol.value(p.var);
+            total_penalty += p_val;
+            
+            // Find the actual time for this entity/instance
+            let instance_time = schedule.iter()
+                .find(|(_, ename, inst, _)| ename == &p.entity_name && inst == &p.instance)
+                .map(|(_, _, _, t)| *t)
+                .unwrap_or(0.0);
+            
+            let hh = (instance_time / 60.0).floor() as i32;
+            let mm = (instance_time % 60.0).round() as i32;
+            
+            // Get window descriptions for this entity
+            let window_descriptions = match entity_windows.get(&p.entity_name) {
+                Some(windows) => windows.iter()
+                    .map(|w| w.time_desc.clone())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                None => "None".to_string(),
+            };
+            
+            let deviation_display = if p_val < 0.001 {
+                "On target".to_string()
+            } else {
+                format!("{:.1} min", p_val)
+            };
+            
+            println!("│ {:<10} | {:<8} | {:<9} | {:<17} │", 
+                     p.entity_name, 
+                     format!("#{} ({:02}:{:02})", p.instance, hh, mm),
+                     deviation_display,
+                     window_descriptions);
         }
-        println!("Total penalty => {total_penalty:.2}");
+        
+        println!("├────────────┴──────────┴───────────┴───────────────────┤");
+        println!("│ Total penalty: {:<39.1} │", total_penalty);
+        println!("└───────────────────────────────────────────────────────┘");
     }
+
+    // Display performance metrics
+    let total_time = start_time.elapsed();
+    println!("\nTotal runtime: {:.2?}", total_time);
+    println!("Number of entities: {}", entities.len());
+    println!("Number of scheduled instances: {}", schedule.len());
+    println!("Number of constraints: {}", constraint_count);
 
     Ok(())
+}
+
+// Helper function to create window descriptions for better reporting
+fn create_window_info_map(entities: &[Entity]) -> HashMap<String, Vec<WindowInfo>> {
+    let mut result = HashMap::new();
+    
+    for e in entities {
+        if e.windows.is_empty() {
+            continue;
+        }
+        
+        let mut windows = Vec::new();
+        
+        for w in &e.windows {
+            match w {
+                WindowSpec::Anchor(a) => {
+                    let hh = a / 60;
+                    let mm = a % 60;
+                    windows.push(WindowInfo {
+                        window_type: "Anchor".to_string(),
+                        time_desc: format!("{:02}:{:02}", hh, mm),
+                    });
+                },
+                WindowSpec::Range(start, end) => {
+                    let start_hh = start / 60;
+                    let start_mm = start % 60;
+                    let end_hh = end / 60;
+                    let end_mm = end % 60;
+                    windows.push(WindowInfo {
+                        window_type: "Range".to_string(),
+                        time_desc: format!("{:02}:{:02}-{:02}:{:02}", 
+                                          start_hh, start_mm, end_hh, end_mm),
+                    });
+                },
+            }
+        }
+        
+        result.insert(e.name.clone(), windows);
+    }
+    
+    result
 }

--- a/generate_schedule_milp/src/parse.rs
+++ b/generate_schedule_milp/src/parse.rs
@@ -1,43 +1,85 @@
-use crate::domain::{Entity, Frequency, ConstraintExpr, ConstraintType, ConstraintRef};
+use crate::domain::{
+    Entity, Frequency, ConstraintExpr, ConstraintType, ConstraintRef,
+    WindowSpec, // newly introduced in domain.rs
+};
 use regex::Regex;
 
+/// Parse the table into a list of `Entity`.
+/// Now expects a table with at least 9 columns:
+///   [0]: Entity
+///   [1]: Category
+///   [2]: Unit
+///   [3]: Amount
+///   [4]: Split
+///   [5]: Frequency
+///   [6]: Constraints
+///   [7]: Windows   (new)
+///   [8]: Note
+///
+/// Returns an error if rows have fewer than 9 columns.
 pub fn parse_from_table(rows: Vec<Vec<&str>>) -> Result<Vec<Entity>, String> {
+    // For parsing the constraints text (JSON-like array of strings),
+    // we reuse the same approach with a regex capturing anything in quotes.
     let re = Regex::new(r#""([^"]+)""#).unwrap();
-    
+
     rows.into_iter()
-        .skip(1) // skip header
+        .skip(1) // skip header row
         .map(|row| {
-            if row.len() < 7 {
-                return Err("Bad row data".to_string());
+            // we now expect at least 9 columns
+            if row.len() < 9 {
+                return Err(format!(
+                    "Bad row data: expected at least 9 columns, got {}",
+                    row.len()
+                ));
             }
-            let cstr = row[6].trim();
-            let cexprs = match cstr {
+
+            // (1) parse constraints
+            let constraints_str = row[6].trim();
+            let cexprs = match constraints_str {
                 "" | "[]" => Vec::new(),
                 _ => re
-                    .captures_iter(cstr)
+                    .captures_iter(constraints_str)
                     .map(|cap| parse_one_constraint(cap[1].trim()))
                     .collect::<Result<Vec<_>, _>>()?,
             };
+
+            // (2) parse windows
+            let windows_str = row[7].trim();
+            let wspecs = match windows_str {
+                "" | "[]" => Vec::new(),
+                _ => {
+                    re.captures_iter(windows_str)
+                        .map(|cap| parse_one_window(cap[1].trim()))
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+            };
+
+            // (3) build the entity
             Ok(Entity {
                 name: row[0].to_string(),
                 category: row[1].to_string(),
                 frequency: Frequency::from_str(row[5]),
                 constraints: cexprs,
+                windows: wspecs, // new field in Entity
             })
         })
         .collect()
 }
 
+/// Parse a single constraint snippet, e.g. "≥8h apart", "≥1h before food", etc.
+///
+/// For example, the string "≥6h apart" is recognized as:
+///   - time_hours = 6
+///   - ctype = ConstraintType::Apart
+///   - cref = ConstraintRef::WithinGroup (since "apart" was recognized)
 pub fn parse_one_constraint(s: &str) -> Result<ConstraintExpr, String> {
-    // pattern array: (regex, constraint type, is_within_group)
     let patterns = &[
-        (r"^≥(\d+)h\s+apart$",            ConstraintType::Apart,     true),
-        (r"^≥(\d+)h\s+before\s+(.+)$",    ConstraintType::Before,    false),
-        (r"^≥(\d+)h\s+after\s+(.+)$",     ConstraintType::After,     false),
-        (r"^≥(\d+)h\s+apart\s+from\s+(.+)$", ConstraintType::ApartFrom, false),
+        (r"^≥(\d+)h\s+apart$",              ConstraintType::Apart,     true),
+        (r"^≥(\d+)h\s+before\s+(.+)$",      ConstraintType::Before,    false),
+        (r"^≥(\d+)h\s+after\s+(.+)$",       ConstraintType::After,     false),
+        (r"^≥(\d+)h\s+apart\s+from\s+(.+)$",ConstraintType::ApartFrom, false),
     ];
 
-    // Use find_map() to locate the first matching pattern and build the ConstraintExpr
     patterns
         .iter()
         .find_map(|(pattern, ctype, is_within_group)| {
@@ -48,8 +90,53 @@ pub fn parse_one_constraint(s: &str) -> Result<ConstraintExpr, String> {
                 } else {
                     ConstraintRef::Unresolved(cap[2].trim().to_string())
                 };
-                Ok(ConstraintExpr { time_hours: hrs, ctype: ctype.clone(), cref })
+                Ok(ConstraintExpr {
+                    time_hours: hrs,
+                    ctype: ctype.clone(),
+                    cref,
+                })
             })
         })
         .unwrap_or_else(|| Err(format!("Unknown constraint expr: {}", s)))
+}
+
+/// Parse a single window snippet, e.g. "08:00" or "12:00-13:00".
+/// Returns a `WindowSpec::Anchor(...)` or `WindowSpec::Range(...)`.
+fn parse_one_window(s: &str) -> Result<WindowSpec, String> {
+    // If there's a dash, assume "start-end" range
+    if let Some(idx) = s.find('-') {
+        let (start_str, end_str) = s.split_at(idx);
+        // split_at keeps the '-' in the second piece, so skip 1
+        let end_str = &end_str[1..];
+
+        let start_min = parse_hhmm_to_minutes(start_str.trim())?;
+        let end_min   = parse_hhmm_to_minutes(end_str.trim())?;
+        if end_min < start_min {
+            return Err(format!(
+                "Window range is reversed or invalid: {}",
+                s
+            ));
+        }
+        Ok(WindowSpec::Range(start_min, end_min))
+    } else {
+        // No dash => interpret as an anchor
+        let anchor = parse_hhmm_to_minutes(s)?;
+        Ok(WindowSpec::Anchor(anchor))
+    }
+}
+
+/// Convert "HH:MM" to minutes from midnight (0..1440).
+fn parse_hhmm_to_minutes(hhmm: &str) -> Result<i32, String> {
+    let parts: Vec<_> = hhmm.split(':').collect();
+    if parts.len() != 2 {
+        return Err(format!("Not in HH:MM format: {}", hhmm));
+    }
+    let hour: i32 = parts[0].parse().map_err(|_| format!("Bad hour: {}", parts[0]))?;
+    let min:  i32 = parts[1].parse().map_err(|_| format!("Bad minute: {}", parts[1]))?;
+
+    if !(0..=23).contains(&hour) || !(0..=59).contains(&min) {
+        return Err(format!("Time out of valid range: {}", hhmm));
+    }
+
+    Ok(hour * 60 + min)
 }


### PR DESCRIPTION
- **feat: implement windows**
- **feat: use windows**
- **feat: windows with debugging (impl O)**
- **feat: window distribution objective**
- **fix: use 2 meal windows**
- **chore: tidy unused reporting fields**
- **style: lint**
- **style: clippy**
- **style: clippy 2**

## Planning

Below is a broad outline for **softening** the window logic, so items do not snap exactly to anchor times or boundaries. This avoids forcing all “Earliest” items into the earliest anchor or “Latest” items into the latest anchor. Instead, we include a small penalty for deviating from each window’s center or range. The solver will balance that penalty against the “Earliest/Latest” objective, producing more “natural” placements within the windows instead of collapsing on the boundary.

---

## 1) Why Your Current Code Snaps to Anchors

1. **Constraint**: You used “If binary = 1, then `t_i` = anchor time.”  
2. **Objective**: The solver’s main objective is `minimize sum(t_i)` (Earliest) or `maximize sum(t_i)` (Latest).  
3. **Result**: Because the solver sees no _cost_ in choosing one anchor over another (aside from fulfilling constraints), it lumps everything at the anchor (or boundary) that best satisfies earliest or latest.

In other words, your current approach is purely “hard constraints”: if an anchor is feasible, the solver picks it to optimize the main objective. That yields these boundary clusterings.

---

## 2) Introduce a “Penalty for Deviation” (Soft Anchoring)

Instead of forcing `t_i` **exactly** to an anchor or range, you can define a **penalty** in the objective that encourages (but does not strictly enforce) alignment with the windows. If a certain anchor or range is convenient given the main objective, the solver will choose it. If not, it can shift away at some penalty cost.

### 2.1 Weighted Sum in the Objective

You can have a single objective:
\[
\text{Objective} = \;\underbrace{(\text{Earliest or Latest}(\sum t_i))}_{\text{main}}\;+\;\alpha \times \underbrace{\sum(\text{deviation penalties})}_{\text{soft windows}}
\]
- If you choose “Earliest,” you do: \(\min (\sum t_i + \alpha \cdot \sum \text{penalty}_i)\).
- If you choose “Latest,” you do: \(\max (\sum t_i - \alpha \cdot \sum \text{penalty}_i)\) or \(\min (-\sum t_i + \alpha\cdot\sum \text{penalty}_i)\).  

The key is that \(\alpha\) is a small weight so that the main objective (earliest or latest) still dominates, but there is a mild incentive to stay near the windows.

### 2.2 Defining a Penalty for Each Task

For each entity instance \( i\), define a new continuous variable \(\delta_i \ge 0\). This variable measures “how far (in minutes) the scheduled time is from the chosen window.”  

If you want multiple windows or ranges, you can define either:

1. **Minimum distance from _any_ window**  
   \(\delta_i \le \text{distance}(t_i, w)\) for each window \(w\). Then \(\delta_i\) is forced to be no greater than all the distances, effectively \(\delta_i = \min_{w} \text{distance}(...)\).  

2. **Pick exactly one window** to measure distance from. This is more complicated (involves a binary pick for each window).  

Below is a simplified version of the “minimum distance from a set of anchors” approach.

---

## 3) Example of a Single “Anchor” or “Center” per Window

**Step A**: For each window \( w\) with a “center” \(c_w\), define:
\[
\text{dist}_{i,w} \ge t_i - c_w,\quad
\text{dist}_{i,w} \ge c_w - t_i,\quad
\text{dist}_{i,w} \ge 0.
\]
So \(\text{dist}_{i,w}\) is \(|t_i - c_w|\).  

**Step B**: Let \(\delta_i\) be the min distance over all windows:
\[
\delta_i \le \text{dist}_{i,w}\quad \forall w \in \{\text{windows}\}.
\]
Hence \(\delta_i \le \min_w(|t_i - c_w|)\). The solver will push \(\delta_i\) as low as possible (since it’s in the objective).

**Step C**: Add to the objective:  
\[
\alpha \sum_i \delta_i.
\]

**Result**: The solver tries to keep \(t_i\) near at least one window center (so \(\delta_i\) is small), while also optimizing the sum of \(t_i\) for earliest or latest. This typically yields a compromise: tasks land near a chosen window if it doesn’t cost too much in the main objective to do so.

---

## 4) Illustrative Pseudocode

Below is a **pseudocode** snippet showing how to add a single soft penalty variable \(\delta_i\) per item, referencing a set of anchors or window centers. (Ranges are covered in the next section.)

```rust
// 1) define an alpha, the penalty weight
let alpha = 0.1; // or some small fraction

// 2) for each entity instance i, build a penalty var delta_i >= 0
let mut penalties = Vec::new();
for (cid, cv) in &clock_map {
    let delta_i = builder.add(variable().continuous().lower_bound(0.0));
    penalties.push(delta_i);

    // Suppose you have some known anchor times
    // from e.windows. Let's say they are WindowSpec::Anchor(c) in minutes:
    // We'll gather them into a list of centers: anchor_centers.
    let anchor_centers = gather_anchor_centers_for(cv.entity_name, &entities);

    for c_w in anchor_centers {
        // define a dist_{i,w} variable
        let dist_iw = builder.add(variable().continuous().lower_bound(0.0));

        // dist_iw >= t_i - c_w
        constraints.push(constraint!( dist_iw >= cv.var - c_w ));
        // dist_iw >= c_w - t_i
        constraints.push(constraint!( dist_iw >= c_w - cv.var ));

        // and delta_i <= dist_iw
        constraints.push(constraint!( delta_i <= dist_iw ));
    }
}

// 3) Build your main sum_expr for earliest or latest
let mut sum_expr = Expression::from(0.0);
for cv in clock_map.values() {
    sum_expr += cv.var;
}

// 4) Build penalty expression
let mut penalty_expr = Expression::from(0.0);
for &p in &penalties {
    penalty_expr += p;
}

// 5) Weighted sum objective
// If earliest => minimize ( sum_expr + alpha * penalty_expr )
// If latest  => maximize ( sum_expr - alpha * penalty_expr ) 
//   or equivalently => minimize ( -sum_expr + alpha * penalty_expr )
let mut problem = match config.strategy {
    ScheduleStrategy::Earliest => {
        builder.minimise(sum_expr + alpha * penalty_expr).using(default_solver)
    }
    ScheduleStrategy::Latest => {
        // one approach:
        builder.minimise(Expression::from(0.0) - sum_expr + alpha * penalty_expr)
               .using(default_solver)
    }
};

for c in constraints {
    problem = problem.with(c);
}
```

**Note**:
- `gather_anchor_centers_for` might read `Entity::windows` and filter for `WindowSpec::Anchor(a)`. For ranges, you can store an approximate “center” or do a different logic (e.g. zero penalty if inside the range, penalty if outside).
- You might want each item to pick exactly **one** window. That requires additional binary variables. The above snippet just calculates “distance to the nearest anchor among the set,” with no restriction on how many windows it can be near.

---

## 5) Handling “Windows as Ranges”

To softly prefer a time inside `[start, end]`, define a penalty that is 0 if `t_i` is inside the range, and grows if it’s outside. For example:

\[
\delta_i \ge \max(0, \,start - t_i,\; t_i - end).
\]
This means \(\delta_i\) is the “distance outside the range.” If `t_i` is within `[start..end]`, the penalty is 0. If it’s below `start`, the penalty is `start - t_i`. If it’s above `end`, the penalty is `t_i - end`. 

In code:

```rust
// If t_i < start => penalty = start - t_i
// If t_i > end   => penalty = t_i - end
// If in [start..end], penalty = 0

// We can do this with 2 new constraints:
delta_i >= start - t_i
delta_i >= t_i - end
delta_i >= 0
```

If you have multiple ranges, either you do “distance to the nearest range” logic or let the item pick which range is best. (That might involve binary variables to pick a range, then measure distance to that range.)

---

## 6) Summation or Hierarchical Approach

Instead of a single weighted objective, you could do a **lexicographic** or **hierarchical** approach:

1. Solve for earliest or latest.  
2. Among solutions that achieve the same optimum for that objective, choose the one that minimizes total penalty.  

Some solvers support multi-stage objectives. Alternatively, you can solve once, record the optimum sum, then add `sum_expr == that_optimum` as a constraint and re-solve minimizing the penalty. This is more advanced but can yield a solution that is strictly earliest (or latest) while also applying the best distribution.

---

## 7) Summary

1. **Simply forcing** the schedule to match anchors or ranges leads to boundary solutions if your main objective is purely “earliest” or “latest.”  
2. **To avoid** everything piling into a single anchor, you need **soft constraints** or **penalties** in the objective.  
3. **Implementation**:
   - Introduce a penalty variable \(\delta_i\) measuring how far a task is from some “preferred” window.  
   - Add \(\alpha \sum \delta_i\) to your objective so the solver tries to keep tasks near the windows.  
   - In “Earliest” or “Latest” mode, it will strike a balance between minimal (or maximal) start times and minimal penalty.  
4. If you want “pick exactly one window from a set,” you add binary variables to pick which window to measure distance from. If you just want “distance from the nearest anchor,” you can define \(\delta_i \le \text{dist}_{i,w}\) for each window \(w\).  

**In short**: Hard constraints about anchors or ranges will lead to boundary clumping for purely earliest or latest. A **soft penalty** approach is necessary to spread tasks more naturally within your chosen windows.

## Plan 2

When you rely **only** on a “distance from window” penalty, the solver sees **no incentive** to use multiple windows if a single window yields zero penalty for *each* instance. In your example, **08:00** is a valid anchor, so **both meals** land exactly there (and incur **zero** penalty). From a “minimize sum of times” standpoint (Earliest), that’s a perfect solution:  
1. Sum of times is pushed as early as possible.  
2. Penalty is zero because both instances are _within_ a window (08:00 anchor).  

If you want tasks distributed **across** windows, you must add **extra constraints or a balancing objective** to “spread out” multiple instances instead of letting them all choose the same anchor.

---

## Why It Bunches at the Same Window

- The solver tries to minimize \(\sum t_i\).  
- Putting both meals at the earliest anchor (08:00 → 480 minutes) yields a minimal sum of times.  
- Each meal’s penalty is zero because 480 is exactly the anchor time.  
- No other part of the current model punishes “using the same window again” or “not using later windows.”

Hence, from the solver’s perspective, the best move is:  
- Put Meal 1 at 08:00  
- Put Meal 2 at 08:00  
- Achieve minimal sum(t) with zero penalty.

---

## How to Force or Encourage Distribution

You need **more** than just a “distance from window” penalty to spread tasks among multiple windows. Common approaches:

### 1) **Capacity Constraints** or “One Task per Window”  
If you truly want “never put two tasks in the same window,” do:  
\[
\sum_{i\in\text{instances}} z_{i,w} \le 1 \quad \text{for each window } w
\]  
and also
\[
\sum_{w} z_{i,w} = 1 \quad \text{for each instance } i
\]  
That forces each instance to pick a *distinct* window. You could adapt this to “2 tasks max per window,” etc.

### 2) **Even/Balanced Distribution**  
If you want tasks to be “as evenly spread as possible,” you can define a small penalty for “how unbalanced the distribution is.” For example, let 
\[
\text{count}_w = \sum_{i} z_{i,w}
\]
Then penalize something like 
\[
\sum_{w, w'} \bigl|\text{count}_w - \text{count}_{w'}\bigr|
\]
or do a simpler approach that tries to keep each window from having too many tasks (unless necessary).

### 3) **Use a Multi-Objective**  
- 1st objective: earliest or latest.  
- 2nd objective: maximize the number of distinct windows used or minimize variance in usage across windows.

### 4) **Hard-Coding Frequency**  
If you specifically know “This entity has 2× daily” and you have 3 windows, you might force it to pick exactly 2 *different* windows:
```rust
// For each entity i that is 2x daily, 
//   ensure instance 1 picks a different window from instance 2.
```
It’s simpler but less general.

---

## In Short

- A mere “distance from window center” penalty only ensures each task is *in or near* **some** window; it doesn’t enforce *different* windows for multiple tasks.  
- To “maximally use windows,” add **distribution constraints** or a **balancing objective**.  
- Without these, the solver sees no difference between placing all meals in the same earliest anchor vs. splitting them across multiple windows—both yield zero penalty and an equally minimal sum(t).

That’s why your meals bunch up at 08:00. You need an additional incentive or rule telling the solver to diversify across windows.

## Plan 3

Below is a **high‐level strategy** to expand your solver so that it **distributes tasks** more evenly across multiple windows rather than bunching them into one:

1. **Assign tasks to windows using binary variables** rather than just measuring distance.  
2. **Restrict or penalize re‐using the same window** – so the solver is nudged to spread instances out.  
3. **Optionally penalize leaving windows unused** if you want to encourage every window’s usage when there are enough tasks.

The idea is to have explicit integer constraints that capture “one instance per window” or “penalty if a window is skipped.” You still can keep (or remove) the “soft distance” idea, but if you truly want “maximally distributed,” you usually need **distribution constraints** beyond just “distance from a window.”

---

## 1) Use Binary “Assignment” Variables for Windows

For each **instance** \(i\) of an entity and each **window** \(w\), define a binary variable:
\[
z_{i,w} = 
\begin{cases}
1 & \text{if instance } i\text{ is placed in window }w,\\
0 & \text{otherwise}.
\end{cases}
\]

Then:

- **Exactly one window per instance**:  
  \[
    \sum_{w} z_{i,w} = 1
    \quad\text{for each instance } i.
  \]

This step forces each instance to choose exactly one window. If you let them pick “none,” you’d do \(\sum_w z_{i,w} \le 1\) – but typically, you want each task to land in exactly one window.

---

## 2) Add Capacity or “One Task per Window” (Optional)

If you truly want “**no two tasks** share the same window,” do:

\[
\sum_{i} z_{i,w} \le 1
\quad\text{for each window } w.
\]

This means each window can hold at most one instance. If you have a total of \(N\) tasks (all entities combined) and \(W\) windows, you might see the solver spread them out as long as \(N \le W\). If \(N > W\), some windows inevitably hold multiple tasks, or you relax the constraint.  

**If you only want** “don’t let two _instances of the *same entity*_ share the same window,” do:

\[
\sum_{\substack{i\text{ in same entity}}} z_{i,w} \le 1.
\]
Other entities could still share that window, but the same entity’s multiple doses can’t collide.

---

## 3) Force an Entity with `F` Instances to Fill `F` Distinct Windows

If an entity’s frequency = 3, that entity has 3 tasks. To ensure each task goes to a different window (like breakfast, lunch, dinner), do:

- The constraint above that only one instance of this entity can occupy a single window:
  \[
    \sum_{\text{instances i of entity E}} z_{i,w} \le 1
    \quad \forall w
  \]
- Then each instance must pick a window:
  \[
    \sum_{w} z_{i,w} = 1 \quad \forall i
  \]
As a result, the 3 tasks each pick a different window (if there are at least 3 windows).  
If `F=2`, the 2 tasks pick 2 distinct windows, and so forth.

---

## 4) Penalize “Skipping a Window” (Optional)

If you have 3 windows and 2 tasks, the solver might still choose windows 1 and 2, leaving window 3 unused. If you want “use as many windows as possible,” define a binary “usage” variable:

\[
\text{use}_w = 1 \quad \text{if window w is used by at least one instance}
\]
\[
\text{use}_w \; \ge \; z_{i,w} \quad \forall i. 
\]
Thus if any instance picks window \(w\), \(\text{use}_w = 1\).  
Then you can **penalize** or **maximize** the number of used windows:

- If you want to penalize skipping:  
  \[
    \text{Penalty} = \sum_{w} (1 - \text{use}_w).
  \]
  Minimizing this penalty tries to minimize the number of 0’s in `use_w`.  
- If you want to maximize used windows, you can add a term \(-\beta \sum_{w} \text{use}_w\) to your objective or do a second objective. 

---

## 5) Spread Out by Index / “No Large Gaps”

If your windows are in a linear order (e.g. window1 = ~08:00, window2 = ~12:00, window3 = ~19:00) and you want to punish skipping “middle” windows, you can do something like:

- Let \(\text{use}_w\) = 1 if window \(w\) is used.  
- Add a penalty for “any time you use window1 and window3 but skip window2.” Something like:

  \[
  \text{Penalty} \; \ge \; \text{use}_{1} + \text{use}_{3} - \text{use}_{2} - 1.
  \]
  
  This forces an additional penalty of 1 if windows 1 and 3 are used while 2 is not. It’s a bit hacky, but it’s one approach. Alternatively, define a penalty for “number of consecutive empty windows.” The main idea is you need **explicit** constraints or penalty terms that identify “we used window 1 and 3 but not 2.”

---

## 6) Combine With Earliest/Latest Objectives

In your code, you’ve used:

\[
\min (\sum t_i + \alpha \sum \text{penalty})
\quad\text{(Earliest plus soft penalty)}
\]

or

\[
\max (\sum t_i - \alpha \sum \text{penalty}).
\]

Now you incorporate an additional penalty or constraints that encourage distribution. For example:

- **If you want** “Earliest but also fill all windows if possible,” you might add a penalty for each unused window: 
  \[
  \text{PenaltyUnused} = \sum_{w} (1 - \text{use}_w).
  \]
  Then your objective becomes
  \[
    \min \Bigl[\sum t_i + \alpha_1 (\text{distance penalty}) + \alpha_2 (\text{PenaltyUnused})\Bigr].
  \]
  This tries to keep times early, keep tasks near the windows, and also fill all windows to avoid the penalty from skipping.

- **Or** you can do a capacity constraint \(\sum_i z_{i,w} \le 1\) so they physically can’t put 2 tasks in the same window, forcing them to spread out. If the number of tasks is equal or less than the number of windows, you’ll see them fill different windows.

---

## 7) Example Summaries

**A) Simple “One Task per Window”**  
1. For each instance \(i\), \(\sum_{w} z_{i,w} = 1\).  
2. For each window \(w\), \(\sum_{i} z_{i,w} \le 1\).  
3. Minimizing sum(t_i) will place tasks at the earliest feasible windows, but no two tasks can occupy the same window, so you’ll see them spread out.

**B) Also Minimizing “Unused Window”**  
Add “usage” variables \(\text{use}_w \ge z_{i,w}\). Then:

\[
\text{penalty} = \sum_{w} (1 - \text{use}_w).
\]
Minimize \(\sum t_i + \alpha \times \text{penalty}\). That tries to fill all windows, unless using them is too costly for the earliest objective.

**C) Frequency Matching**  
If an entity has 3 tasks a day and you have 3 windows, enforce \(\sum_{w} z_{i,w} = 1\) per instance and \(\sum_{i\in E} z_{i,w} \le 1\) so that entity’s 3 tasks must pick 3 distinct windows (assuming 3 tasks ≤ 3 windows). They effectively fill them all.

---

## Final Takeaway

To truly “distribute” tasks evenly:

1. **Use binary assignment to windows** rather than pure distance‐to‐windows variables.  
2. **Enforce** or **penalize** re‐using the same window.  
3. **(Optional) penalize** leaving some windows empty if you want them all used.  
4. Combine with “earliest or latest” in the objective by adding your new distribution penalties or constraints.

Distance‐only penalties *don’t* guarantee distribution. You need explicit **capacity, usage, or balancing** constraints (or objective terms) that reward using each window at most once and/or punish skipping windows.

## Plan 4

Below is a **consolidated “real” implementation** that merges:

1. **Your existing “apart/before/after” constraints**  
2. **Binary “window assignment”** for distributing tasks across windows  
3. **Penalizing unused windows** so the solver tries to fill them—rather than lumping tasks into just one  

It is **not** a toy snippet; it extends your original `main.rs` while keeping your real constraints logic. The only major additions are the new distribution logic (binary assignment variables) plus a capacity penalty for unfilled windows. 

---

## Outline of Changes

1. **Preserve** your original constraints: “apart,” “before/after,” “apart from,” etc.  
2. **Add** a set of global windows (three in this example).  
3. **For each clock variable** (i.e., each entity instance), create a set of binary variables \(z_{i,w}\).  
4. **Force each instance** to pick exactly one window.  
5. **Big‐M** “snap” each instance’s start time to that window’s center if \(z_{i,w}=1\).  
6. **No multiple tasks** from the same entity in the same window: \(\sum_{i\in E} z_{i,w} \le 1\).  
7. **`use_w`** binary variable indicates whether window \(w\) was used at all.  
8. **Penalize** skipping windows by summing \((1 - \text{use}_w)\).  
9. **Combine** this penalty with your earliest or latest objective.  

The solver can’t just place all tasks in the earliest (or latest) anchor, because that would cause multiple tasks of the same entity to share a window (violating \(\sum_{i\in E} z_{i,w}\le 1\)) or skip other windows, incurring penalty if you make that cost big enough.

---

## Full `main.rs`

```rust
mod domain;
mod parse;
mod cli;

use crate::cli::{ScheduleStrategy, parse_config_from_args};
use crate::domain::{
    Entity, ClockVar, c2str, WindowSpec, 
    ConstraintType, ConstraintRef,
};
use crate::parse::parse_from_table;

use good_lp::{
    variables, variable, constraint, default_solver,
    SolverModel, Solution, Expression, Constraint
};
use std::collections::{HashMap, HashSet};
use std::error::Error;

fn main() -> Result<(), Box<dyn Error>> {
    // 1) CLI config
    let config = parse_config_from_args();
    println!("Using day window: {}..{} (min)", config.day_start_minutes, config.day_end_minutes);
    println!("Strategy: {:?}", config.strategy);

    // 2) Example table data
    // We keep your real constraints in place ("≥8h apart", etc.).
    // We'll define a 3-window approach for distribution.
    let table_data = vec![
        vec![
            "Entity","Category","Unit","Amount","Split","Frequency","Constraints","Windows","Note"
        ],
        vec![
            "Gabapentin","med","ml","1.8","null","2x daily","[\"≥8h apart\"]","[]","null",
        ],
        vec![
            "Pardale","med","tablet","null","2","2x daily","[\"≥8h apart\"]","[]","null",
        ],
        vec![
            "Pro-Kolin","med","ml","3.0","null","2x daily","[]","[]","with food",
        ],
        vec![
            "Antepsin","med","tablet","null","3","3x daily",
            "[\"≥6h apart\", \"≥1h before food\", \"≥2h after food\"]",
            "[]","in 1tsp water",
        ],
        vec![
            "Chicken and rice","food","meal","null","null","2x daily","[]",
            "[]","some note", // We'll rely on distribution constraints for this
        ],
    ];

    // 3) Parse
    let entities = parse_from_table(table_data)?;

    // 4) Build category->entity map
    let mut category_map: HashMap<String, HashSet<String>> = HashMap::new();
    for e in &entities {
        category_map.entry(e.category.clone())
            .or_insert_with(HashSet::new)
            .insert(e.name.clone());
    }

    // 5) Build ILP variables for each entity instance
    let mut builder = variables!();
    let mut clock_map = HashMap::new();

    for e in &entities {
        let count = e.frequency.instances_per_day();
        for i in 0..count {
            let var_name = format!("{}_{}", e.name, i+1);
            // We'll keep them integer for clarity
            let var = builder.add(
                variable().integer()
                    .min(config.day_start_minutes as f64)
                    .max(config.day_end_minutes as f64)
            );
            clock_map.insert(var_name, ClockVar {
                entity_name: e.name.clone(),
                instance: i+1,
                var,
            });
        }
    }

    // We'll store constraints in a vector
    let mut constraints = Vec::new();
    fn add_dbg(desc: &str, c: Constraint, list: &mut Vec<Constraint>) {
        println!("DEBUG => {desc}");
        list.push(c);
    }

    // 6) Build an entity->Vec<ClockVar> map
    let mut entity_clocks: HashMap<String, Vec<ClockVar>> = HashMap::new();
    for cv in clock_map.values() {
        entity_clocks.entry(cv.entity_name.clone())
            .or_default()
            .push(cv.clone());
    }
    for list in entity_clocks.values_mut() {
        list.sort_by_key(|c| c.instance);
    }

    // 7) Helper to resolve references
    let resolve_ref = |rstr: &str| -> Vec<ClockVar> {
        let mut out = Vec::new();
        // is it an entity name?
        for e in &entities {
            if e.name.eq_ignore_ascii_case(rstr) {
                if let Some(cl) = entity_clocks.get(&e.name) {
                    out.extend(cl.clone());
                }
            }
        }
        if !out.is_empty() {
            return out;
        }
        // else check if it's a category
        if let Some(nameset) = category_map.get(rstr) {
            for nm in nameset {
                if let Some(cl) = entity_clocks.get(nm) {
                    out.extend(cl.clone());
                }
            }
        }
        out
    };

    let big_m = 1440.0;

    // 8) Apply the original "apart/before/after" constraints
    for e in &entities {
        let eclocks = match entity_clocks.get(&e.name) {
            Some(list) => list,
            None => continue,
        };

        let mut ba_map: HashMap<String, (Option<f64>, Option<f64>)> = HashMap::new();
        let mut apart_intervals = Vec::new();
        let mut apart_from_list = Vec::new();

        for cexpr in &e.constraints {
            let tv_min = cexpr.time_hours as f64 * 60.0;
            match cexpr.ctype {
                ConstraintType::Apart => {
                    // consecutive
                    apart_intervals.push(tv_min);
                }
                ConstraintType::ApartFrom => {
                    if let ConstraintRef::Unresolved(r) = &cexpr.cref {
                        apart_from_list.push((tv_min, r.clone()));
                    }
                }
                ConstraintType::Before => {
                    if let ConstraintRef::Unresolved(r) = &cexpr.cref {
                        let ent = ba_map.entry(r.clone()).or_insert((None, None));
                        ent.0 = Some(tv_min);
                    }
                }
                ConstraintType::After => {
                    if let ConstraintRef::Unresolved(r) = &cexpr.cref {
                        let ent = ba_map.entry(r.clone()).or_insert((None, None));
                        ent.1 = Some(tv_min);
                    }
                }
            }
        }

        // (a) consecutive "apart"
        for tv in apart_intervals {
            for w in eclocks.windows(2) {
                let c1 = &w[0];
                let c2 = &w[1];
                let desc = format!("(Apart) {} - {} >= {}", c2str(c2), c2str(c1), tv);
                add_dbg(&desc, constraint!( c2.var - c1.var >= tv ), &mut constraints);
            }
        }

        // (b) "apart_from" => big-M disjunction
        for (tv, refname) in apart_from_list {
            let rvars = resolve_ref(&refname);
            for c_e in eclocks {
                for c_r in &rvars {
                    let b = builder.add(variable().binary());
                    let d1 = format!("(ApartFrom) {} - {} >= {} - bigM*(1-b)", c2str(c_r), c2str(c_e), tv);
                    add_dbg(&d1, constraint!( c_r.var - c_e.var >= tv - big_m*(1.0 - b)), &mut constraints);
                    let d2 = format!("(ApartFrom) {} - {} >= {} - bigM*b", c2str(c_e), c2str(c_r), tv);
                    add_dbg(&d2, constraint!( c_e.var - c_r.var >= tv - big_m*b ), &mut constraints);
                }
            }
        }

        // (c) merges of "before & after"
        for (rname, (maybe_b, maybe_a)) in ba_map {
            let rvars = resolve_ref(&rname);
            match (maybe_b, maybe_a) {
                (Some(bv), Some(av)) => {
                    // "≥bv before OR ≥av after"
                    for c_e in eclocks {
                        for c_r in &rvars {
                            let b = builder.add(variable().binary());
                            let d1 = format!("(Before|After) {} - {} >= {} - M*(1-b)", c2str(c_r), c2str(c_e), bv);
                            add_dbg(&d1, constraint!( c_r.var - c_e.var >= bv - big_m*(1.0 - b) ), &mut constraints);
                            let d2 = format!("(Before|After) {} - {} >= {} - M*b", c2str(c_e), c2str(c_r), av);
                            add_dbg(&d2, constraint!( c_e.var - c_r.var >= av - big_m*b ), &mut constraints);
                        }
                    }
                }
                (Some(bv), None) => {
                    // only "before"
                    for c_e in eclocks {
                        for c_r in &rvars {
                            let d = format!("(Before) {} - {} >= {}", c2str(c_r), c2str(c_e), bv);
                            add_dbg(&d, constraint!( c_r.var - c_e.var >= bv ), &mut constraints);
                        }
                    }
                }
                (None, Some(av)) => {
                    // only "after"
                    for c_e in eclocks {
                        for c_r in &rvars {
                            let d = format!("(After) {} - {} >= {}", c2str(c_e), c2str(c_r), av);
                            add_dbg(&d, constraint!( c_e.var - c_r.var >= av ), &mut constraints);
                        }
                    }
                }
                (None, None) => {}
            }
        }
    }

    // 9) Windows for distribution
    // We'll define 3 windows (08:00, 12:00, 19:00). The solver must pick distinct windows for
    // the multiple tasks of each entity => no bunching. Also we penalize skipping windows.
    let global_windows = vec![
        ("W1", 8.0 * 60.0),   // 08:00
        ("W2", 12.0 * 60.0),  // 12:00
        ("W3", 19.0 * 60.0),  // 19:00
    ];

    // For each instance, define z_{i,w}. Also define use_w => 1 if window is used by any instance
    let mut assignment_vars = HashMap::new();
    let mut use_vars = HashMap::new();

    for (w_name, _) in &global_windows {
        let u = builder.add(variable().binary());
        use_vars.insert(w_name.to_string(), u);
    }

    // For each clock var i, we do sum_w z_{i,w} = 1; if z_{i,w}=1 => t_i = w_center
    for (cid, cv) in &clock_map {
        let mut z_list = Vec::new();
        for (w_idx, (w_name, w_center)) in global_windows.iter().enumerate() {
            let z = builder.add(variable().binary());
            assignment_vars.insert((cid.clone(), w_name.clone()), z);
            z_list.push(z);

            // Big-M snap:
            let d1 = format!("(Snap) {} - {} <= M*(1-z_{})", c2str(cv), w_center, cid);
            add_dbg(&d1,
                constraint!( cv.var - *w_center <= big_m*(1.0 - z) ),
                &mut constraints
            );
            let d2 = format!("(Snap) {} - {} <= M*(1-z_{})", w_center, c2str(cv), cid);
            add_dbg(&d2,
                constraint!( *w_center - cv.var <= big_m*(1.0 - z) ),
                &mut constraints
            );

            // use_w >= z
            let use_w = use_vars.get(w_name).unwrap();
            let d3 = format!("(UseWin) {}_use >= z_{}", w_name, cid);
            add_dbg(&d3,
                constraint!( *use_w >= z ),
                &mut constraints
            );
        }
        // Exactly one window
        let sumz = z_list.iter().fold(Expression::from(0.0), |acc, &var| acc + var);
        let c_onew = format!("(OneWin) sum_w z_{} == 1", cid);
        add_dbg(&c_onew, constraint!( sumz == 1 ), &mut constraints);
    }

    // 10) "No multiple tasks from the same entity in the same window"
    // sum_{(entity e's tasks)} z_{i,w} <= 1
    for e in &entities {
        let eclocks = entity_clocks.get(&e.name).unwrap_or(&Vec::new());
        for (w_name, _) in &global_windows {
            let mut expr = Expression::from(0.0);
            for cv in eclocks {
                let cid = format!("{}_{}", cv.entity_name, cv.instance);
                if let Some(&z) = assignment_vars.get(&(cid, w_name.clone())) {
                    expr += z;
                }
            }
            let no_bunch = format!("(NoBunch) entity {} in w {} => sum_z <= 1", e.name, w_name);
            add_dbg(&no_bunch, constraint!( expr <= 1 ), &mut constraints);
        }
    }

    // 11) Build objective => earliest or latest + penalize unused windows
    // penalty_unused = sum_{w} (1 - use_w)
    let mut sum_expr = Expression::from(0.0);
    for cv in clock_map.values() {
        sum_expr += cv.var;
    }

    let mut penalty_unused = Expression::from(0.0);
    for (w_name, &u) in &use_vars {
        penalty_unused += 1.0 - u;
    }
    // if you want it strongly forced to fill windows, pick alpha high
    let alpha = 100.0; // A big number so leaving windows empty is expensive

    let mut problem = match config.strategy {
        ScheduleStrategy::Earliest => {
            println!("DEBUG => Minimizing [ sum_times + alpha * unused ]");
            builder.minimise(sum_expr + alpha * penalty_unused).using(default_solver)
        }
        ScheduleStrategy::Latest => {
            println!("DEBUG => Minimizing [ -sum_times + alpha * unused ] => (maximize sum_times - alpha * unused)");
            builder.minimise(Expression::from(0.0) - sum_expr + alpha * penalty_unused)
                   .using(default_solver)
        }
    };

    for c in constraints {
        problem = problem.with(c);
    }

    // 12) Solve
    let sol = match problem.solve() {
        Ok(s) => s,
        Err(e) => {
            eprintln!("Solver error => {e}");
            return Err(format!("Solve error: {e}").into());
        }
    };

    // 13) Extract solution
    let mut schedule = Vec::new();
    for (cid, cv) in &clock_map {
        let val = sol.value(cv.var);
        schedule.push((cid.clone(), cv.entity_name.clone(), val));
    }
    schedule.sort_by(|a,b| a.2.partial_cmp(&b.2).unwrap());

    println!("--- Final schedule ({:?}) ---", config.strategy);
    for (cid, ename, t) in &schedule {
        let hh = (t/60.0).floor() as i32;
        let mm = (t%60.0).round() as i32;
        println!("  {cid} ({ename}): {hh:02}:{mm:02}");
    }

    // Show usage
    println!("\n--- Window usage ---");
    for (w_name, &u) in &use_vars {
        let used = sol.value(u);
        println!("  {w_name}: used={used}");
    }

    // Show each instance's chosen window
    println!("\n--- Window assignments ---");
    for ((cid, w_name), &z) in &assignment_vars {
        let zval = sol.value(z);
        if zval > 0.5 {
            println!("  {cid} => {w_name}");
        }
    }

    Ok(())
}
```

### Explanation

1. **We keep** your real “apart” constraints exactly as in your earlier code.  
2. **We define** a set of windows (`W1=08:00`, `W2=12:00`, `W3=19:00`) as anchors.  
3. **For each instance** `(cid, cv)`, we create `z_{(cid, w)}`.  
4. **One‐window rule**: `sum_w z_{(cid,w)} = 1`.  
5. **No double usage**: for each entity’s tasks, we do `sum_{i} z_{(cid,w)} <= 1`. If an entity has 3 tasks, it must occupy 3 distinct windows (assuming at least 3 windows exist). This keeps them from bunching.  
6. **`use_w >= z_{(cid,w)}`** means if any instance picks window `w`, then `use_w=1`.  
7. **We add** an “unused window penalty”: sum of `(1 - use_w)`. Then we multiply it by a large `alpha` so the solver tries not to skip any window—unless that conflicts heavily with earliest (or latest).  
8. **Earliest** => we do \(\min(\sum(t_i) + \alpha \times \text{unused\_windows})\).  
   - The solver tries to push tasks as early as possible but also tries to avoid leaving a window unused.  
9. **Latest** => \(\min(-\sum(t_i) + \alpha \times \text{unused\_windows})\).  
   - Equivalent to maximizing \(\sum(t_i) - \alpha \times \text{unused\_windows}\).  

You can tune `alpha`. If you set `alpha` extremely high, the solver will strongly prefer using *all* windows over pushing tasks earlier/later. If you reduce `alpha`, you get more weight on “earliest or latest,” potentially ignoring a window or two if that helps place tasks better.  

With these distribution constraints, tasks are forced to spread across the 3 windows, and skipping a window is penalized. That’s how you avoid “bunching up.”  

---

### Customizing

- **Number of windows**: Add or remove from `global_windows`.  
- **One window per entity** vs. “One window per instance” is already shown—this code picks a separate window for each instance but disallows multiple tasks from the same entity in the same window.  
- **Penalizing big gaps**: You could add a separate measure if W1 and W3 are used but W2 is not.  
- **Entity frequencies**: If an entity has 3 tasks daily, it will fill 3 distinct windows.  

This is a “real” implementation using your constraints, **not** a toy snippet. It merges your existing logic with a distribution approach that ensures windows are used and tasks don’t bunch up.
